### PR TITLE
Fix for Travis failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+before_install:
+  - gem install bundler
 rvm:
   - 2.2
   - 2.1


### PR DESCRIPTION
It looks like the Travis failures are common, and due to it's version of bundler being old.
